### PR TITLE
Фикс проверки минут во времени встречи

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -47,7 +47,7 @@ function CalcEndTime() {
         ET = `${YearURL}${MonthURL}${DateURL}T${HourURL}${parseInt(MinutesURL) + 30}00`
       } else if(parseInt(MinutesURL) > 30) {
         ET = `${YearURL}${MonthURL}${DateURL}T${parseInt(HourURL) + 1}${parseInt(MinutesURL) - 30}00`
-      } else if(parseInt(MinutesURL) = 30) {
+      } else {
         ET = `${YearURL}${MonthURL}${DateURL}T${parseInt(HourURL) + 1}${parseInt(MinutesURL) - 30}00`
       }
       break;
@@ -59,7 +59,7 @@ function CalcEndTime() {
         ET = `${YearURL}${MonthURL}${DateURL}T${parseInt(HourURL) + 1}${parseInt(MinutesURL) + 30}00`
       } else if(parseInt(MinutesURL) > 30) {
         ET = `${YearURL}${MonthURL}${DateURL}T${parseInt(HourURL) + 2}${parseInt(MinutesURL) - 30}00`
-      } else if(parseInt(MinutesURL) = 30) {
+      } else {
         ET = `${YearURL}${MonthURL}${DateURL}T${parseInt(HourURL) + 2}${parseInt(MinutesURL) - 30}00`
       }
       break;


### PR DESCRIPTION
Специально проверять, что время вида "XX:30" не нужно, потому что предыдущие проверки исключают все остальные возможные значения.